### PR TITLE
Support ARM64 architectures

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,10 @@ FROM browserless/chrome
 # install system dependency for pak
 USER root
 RUN apt-get update && apt-get install -y \
+  # {pak}
   libcurl4-openssl-dev \
   libxml2-dev \
   libfontconfig1-dev \
+  liblapack-dev libblas-dev \
+  libxml2-dev \
   && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,10 +3,14 @@ FROM browserless/chrome
 # install system dependency for pak
 USER root
 RUN apt-get update && apt-get install -y \
+  # {Matrix}
+  gfortran \
   # {pak}
   libcurl4-openssl-dev \
-  libxml2-dev \
+  # {systemfonts}
   libfontconfig1-dev \
+  # {nlme}
   liblapack-dev libblas-dev \
+  # {xml2}
   libxml2-dev \
   && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM browserless/chrome
+
+# install system dependency for pak
+USER root
+RUN apt-get update && apt-get install -y \
+  libcurl4-openssl-dev \
+  libxml2-dev \
+  libfontconfig1-dev \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,8 @@
 		"ghcr.io/rocker-org/devcontainer-features/r-apt:latest": {},
 
 		// Install additional R package dependencies
+		// Note: httpgd has been archived on CRAN as of 2025-04-23, see
+		// https://cran.r-project.org/web/packages/httpgd/index.html
 		"ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
 			"packages": "dplyr, ggplot2, github::nx10/httpgd, languageserver, rmarkdown"
 		}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // https://github.com/rocker-org/devcontainer-features
 {
 	"name": "My Awesome Report",
-	"image": "selenium/standalone-chrome",
+	"image": "browserless/chrome",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
@@ -15,15 +15,15 @@
 		// Configure R on Ubuntu
 		// More info: https://github.com/rocker-org/devcontainer-features/tree/main/src/r-apt.
 		"ghcr.io/rocker-org/devcontainer-features/r-apt:latest": {
-			"vscodeRSupport": "full",
+			// "vscodeRSupport": "full",
 			"installRMarkdown": true
-		},
-
-		// Install additional R package dependencies
-		"ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
-			"packages": "dplyr, ggplot2",
-			"additionalRepositories": "CRAN = 'https://packagemanager.posit.co/cran/__linux__/jammy/latest'"
 		}
+
+		// Uncomment to install additional R package dependencies
+		// "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
+		// 	"packages": "dplyr, ggplot2",
+		// 	"additionalRepositories": "CRAN = 'https://packagemanager.posit.co/cran/__linux__/jammy/latest'"
+		// }
 
 	},
 
@@ -31,6 +31,9 @@
 	"overrideFeatureInstallOrder": [
 		"ghcr.io/rocker-org/devcontainer-features/r-apt"
 	],
+
+	// Installing R package dependencies without pak
+	"postCreateCommand": ["Rscript", "-e", "install.packages(c('dplyr', 'ggplot2', 'rmarkdown'))"],
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -51,3 +54,4 @@
 	// Connect as root user. More info: https://aka.ms/dev-containers-non-root.
 	"remoteUser": "root"
 }
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,11 +37,12 @@
 			"settings": {
 				"editor.rulers": [80]
 			},
+			// We also recommend installing the `tomoki1207.pdf` extension,
+			// but it needs to be installed locally (not in Dev Container)
 			"extensions": [
 				"quarto.quarto",
 				"RDebugger.r-debugger",
-				"REditorSupport.r",
-				"tomoki1207.pdf"
+				"REditorSupport.r"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 // https://github.com/rocker-org/devcontainer-features
 {
 	"name": "My Awesome Report",
-	"image": "browserless/chrome",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
@@ -14,16 +16,12 @@
 
 		// Configure R on Ubuntu
 		// More info: https://github.com/rocker-org/devcontainer-features/tree/main/src/r-apt.
-		"ghcr.io/rocker-org/devcontainer-features/r-apt:latest": {
-			// "vscodeRSupport": "full",
-			"installRMarkdown": true
-		}
+		"ghcr.io/rocker-org/devcontainer-features/r-apt:latest": {},
 
-		// Uncomment to install additional R package dependencies
-		// "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
-		// 	"packages": "dplyr, ggplot2",
-		// 	"additionalRepositories": "CRAN = 'https://packagemanager.posit.co/cran/__linux__/jammy/latest'"
-		// }
+		// Install additional R package dependencies
+		"ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
+			"packages": "dplyr, ggplot2, github::nx10/httpgd, languageserver, rmarkdown"
+		}
 
 	},
 
@@ -31,9 +29,6 @@
 	"overrideFeatureInstallOrder": [
 		"ghcr.io/rocker-org/devcontainer-features/r-apt"
 	],
-
-	// Installing R package dependencies without pak
-	"postCreateCommand": ["Rscript", "-e", "install.packages(c('dplyr', 'ggplot2', 'rmarkdown'))"],
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -54,4 +49,3 @@
 	// Connect as root user. More info: https://aka.ms/dev-containers-non-root.
 	"remoteUser": "root"
 }
-

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ We assume that you have Git, Docker, and VSCode installed.
 
 This will build the Docker image locally (which will take a few minutes the first time you do this) and then spin up a Docker container that will serve as your development environment in VSCode. You can continue working in VSCode as you normally would! If you make changes to any of the files in the [.devcontainer/](.devcontainer/) directory, you will need to rebuild the image.
 
+### Architecture Support
+
+This has been tested on both AMD64 and ARM64 architectures.
+
 ### Rendering the Report
 
 To render the [example report](my-awesome-report.qmd), run `quarto render my-awesome-report.qmd` from the terminal, and check the newly-created `_output/` directory once it finishes knitting.


### PR DESCRIPTION
## Purpose

We have successfully added support for ARM64 architectures.  This included making the following changes:

1. Switching from `selenium/standalone-chrome` base image (specified in `devcontainer.json`) to the `browserless/chrome` base image (specified in a Dockerfile).
2. Move away from installing `{httpgd}`, `{languageserver}` and `{rmarkdown}` via the options for the [r-apt Dev Conatiner feature](https://github.com/rocker-org/devcontainer-features/tree/main/src/r-apt) and instead are specifying them explicitly in the `r-packages` Dev Container feature.
3. Installing some system packages that {pak} wasn't automatically installing (see Dockerfile).

## Additional Notes

-  We removed the installation of the `tomoki1207.pdf` VSCode extension from within the Dev Container, as it is recommended to install it outside of the Dev Container (in your local VS Code environment, which will still be available to the Dev Container).
- The built Docker image is larger than it previously was, which appears to be mostly due to the size of the new `browserless/chrome` base image we are using. 