### PR TITLE
Multi arch build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,11 +6,21 @@
 		"target": "dev"
 	},
 
-	// Install the `arf` R terminal and R packages for developing in VScode
-	"postCreateCommand": {
-	    "arf": "apt-get update -qq && apt-get install -y -qq curl xz-utils && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/eitsupi/arf/releases/latest/download/arf-console-installer.sh | sh",
-	    "r-packages": "R -q -e \"pak::pkg_install(c('ggplot2', 'gt', 'httpgd', 'languageserver', 'targets', 'tibble'))\""
-	},
+	// Install the `arf` R terminal and R packages for developing in VScode.
+	// Run as a single sequential script (rather than the object form, whose
+	// entries run in parallel) so arf's apt-get calls can't race pak's own
+	// apt-get sysreqs installation and deadlock on the dpkg lock.
+	"postCreateCommand": [
+		"bash",
+		".devcontainer/postCreate.sh",
+		// Specify list of R packages
+		"ggplot2",
+		"gt",
+		"httpgd",
+		"languageserver",
+		"targets",
+		"tibble"
+	],
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+echo "==> Installing system dependencies for arf..."
+apt-get update -qq
+apt-get install -y -qq curl xz-utils
+
+echo "==> Installing arf R terminal..."
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/eitsupi/arf/releases/latest/download/arf-console-installer.sh | sh
+
+if [ "$#" -eq 0 ]; then
+  echo "==> No R packages specified, skipping pak install."
+else
+  echo "==> Installing R packages via pak: $*"
+  packages=$(printf "'%s', " "$@")
+  packages="${packages%, }"
+  R -q -e "pak::pkg_install(c(${packages}))"
+fi
+
+echo "==> ✅ postCreateCommand complete."

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Force LF regardless of platform/core.autocrlf so this script bind-mounted into
+# the (Linux) dev container never gets checked out with CRLF endings.
+.devcontainer/postCreate.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,32 +5,40 @@ ARG R_VERSION=4.5.2
 FROM rocker/r-ver:${R_VERSION} AS dev
 
 # Define the versions of the other software dependencies we'll be using
-ARG QUARTO_VERSION=1.8.27
+ARG QUARTO_VERSION=1.9.38
 
-# Install fonts
+# Install fonts, along with the shared libraries that Chrome Headless Shell
+# (installed below) needs at runtime to render mermaid/graphviz diagrams.
 RUN apt-get update && apt-get install --no-install-recommends -y \
     fonts-roboto \
-  && rm -rf /var/lib/apt/lists/*
-
-# Install Chrome
-RUN apt-get update && apt-get install --no-install-recommends -y \
     wget \
-    gnupg2 \
-  && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
-  && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
-     > /etc/apt/sources.list.d/google-chrome.list \
-  && apt-get update && apt-get install --no-install-recommends -y \
-    google-chrome-stable \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0t64 \
+    libatk-bridge2.0-0t64 \
+    libatspi2.0-0t64 \
+    libdbus-1-3 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libxkbcommon0 \
+    libasound2t64 \
+    libgbm1 \
+    libcups2t64 \
+    libpango-1.0-0 \
+    libcairo2 \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Quarto
-RUN wget -q "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.deb" \
-  && dpkg -i "quarto-${QUARTO_VERSION}-linux-amd64.deb" \
-  && rm "quarto-${QUARTO_VERSION}-linux-amd64.deb"
+# Install Quarto, along with Chrome Headless Shell - Quarto's purpose-built
+# headless browser (Chrome for Testing) used to render mermaid/graphviz
+# diagrams. It ships native arm64 and amd64 Linux builds and needs no system
+# Chrome/Chromium package, unlike the apt-based Chrome install this replaced.
 ARG TARGETARCH
 RUN wget -q "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
   && dpkg -i "quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
   && rm "quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
+  && quarto install chrome-headless-shell --no-prompt
 
 # Install the latest version of {pak}
 RUN R -q -e "install.packages('pak')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Define the version of R that we'll be using
-ARG R_VERSION=4.5.2
+ARG R_VERSION=4.6.0
 
 # Use the rocker/verse base image to install the specific version of R
 FROM rocker/r-ver:${R_VERSION} AS dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN wget -q "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.deb" \
   && dpkg -i "quarto-${QUARTO_VERSION}-linux-amd64.deb" \
   && rm "quarto-${QUARTO_VERSION}-linux-amd64.deb"
+ARG TARGETARCH
+RUN wget -q "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
+  && dpkg -i "quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
+  && rm "quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
 
 # Install the latest version of {pak}
 RUN R -q -e "install.packages('pak')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ENV RENV_CONFIG_SANDBOX_ENABLED=false
 ENV RENV_CONFIG_SYNCHRONIZED_CHECK=false
 
 # Define the version of {renv} to install
-ARG RENV_VERSION=1.1.7
+ARG RENV_VERSION=1.2.3
 
 # Install {renv}
 # Note that we won't use {renv} to install packages during development;

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ARG QUARTO_VERSION=1.9.38
 # (installed below) needs at runtime to render mermaid/graphviz diagrams.
 RUN apt-get update && apt-get install --no-install-recommends -y \
     fonts-roboto \
+    fonts-noto-color-emoji \
     wget \
     libnss3 \
     libnspr4 \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository provides a template framework for authoring PDF reports with [Quarto](https://quarto.org/) inside of a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers), as well as deploying them as reproducible software artifacts via [Docker]().
 
 > [!NOTE]
-> This has been tested on both AMD64 and ARM64 architectures. Both the **Development** and **Deployment** steps are working on AMD64. On our ARM64 tests, the **Development** steps are working, but the **Deployment** steps are throwing an error. See [Issue 15](https://github.com/ketchbrookanalytics/quarto-pdf-dev/issues/15) for more information.
+> This repository has been tested on both AMD64 and ARM64 architectures.
 
 ## Development
 
@@ -49,7 +49,7 @@ As you develop, you'll likely have the need to install additional R packages. In
 
 The devcontainer also offers the following additional features:
 
-- The [arf](https://github.com/eitsupi/arf) R terminal for a friendly R console experience that includes auto-complete and syntax highlighting. 
+- The [arf](https://github.com/eitsupi/arf) R terminal for a friendly R console experience that includes auto-complete and syntax highlighting.
 - Use of [Air](https://posit-dev.github.io/air/) for R code formatting.
 - [Claude Code](https://code.claude.com/docs/en/vs-code) VSCode extension for AI-assisted development.
 
@@ -66,7 +66,7 @@ renv::init(bare = TRUE)   # Answer "y" / "Yes", then restart R
 # Allow {renv} to use the already installed version of {pak}
 renv::hydrate(packages = "pak")   # Answer "Y" / "Yes"
 
-# Enable `renv::dependencies()` (it requires {yaml} be installed) 
+# Enable `renv::dependencies()` (it requires {yaml} be installed)
 renv::install("yaml")
 
 # Discover project R package dependencies
@@ -128,7 +128,7 @@ The middle lines of the above command represent communication between our local 
 This repository contains the following components:
 
 - [_targets/](_targets/) contains [{targets}](https://docs.ropensci.org/targets/) pipeline metadata.
-- [.claude/](.claude/) contains specific instructions and permission settings for Claude Code. 
+- [.claude/](.claude/) contains specific instructions and permission settings for Claude Code.
 - [devcontainer.json](.devcontainer/devcontainer.json) builds upon the [Dockerfile](Dockerfile) by incorporating additional features into the development environment.
 - [assets/](assets/) contains custom [Typst](https://quarto.org/docs/output-formats/typst.html) specifications.
     + [typst-template.typ](assets/typst-template.typ) outlines the [Typst template](https://typst.app/docs/tutorial/making-a-template/) that is used to create the report.

--- a/assets/typst-show.typ
+++ b/assets/typst-show.typ
@@ -15,7 +15,7 @@ $if(author-email)$
   author-email: [$author-email$],
 $endif$
 $if(author-phone)$
-  author-phone: "$author-phone$",
+  author-phone: [$author-phone$],
 $endif$
 $if(toc)$
   toc: $toc$,

--- a/assets/typst-template.typ
+++ b/assets/typst-template.typ
@@ -106,7 +106,7 @@
   align(center)[
       #if author != "" {strong(author); linebreak();}
       #if author-email != "" {link("mailto:" + to-string(author-email)); linebreak();}
-      #if author-phone != "" {author-phone; linebreak();}
+      #if author-phone != "" {to-string(author-phone); linebreak();}
     ]
 
   pagebreak()

--- a/report.qmd
+++ b/report.qmd
@@ -8,6 +8,14 @@ subtitle: With a Really Cool Subtitle
 library(gt)
 ```
 
+## Using Emojis
+
+We like to use the following emojis in many of our reports:
+
+- 🔴 Red
+- 🟡 Yellow
+- 🟢 Green
+
 ## Using {gt} for Tables
 
 {{< include /qmd/_01_tables.qmd >}}


### PR DESCRIPTION
Closes #15.

## Overview

This PR adds multi-architecture support by identifying the host architecture and supplying the `TARGETARCH` argument to the Quarto install. This eliminates the need to pass the `--platform=linux/amd64` flag when building the base image for host machines that are ARM64. As the base image is no longer emulated, performance while in the container environment has (anecdotally) improved dramatically.

This PR also pins the Quarto version at `1.9.38` to leverage [`CHROME HEADLESS SHELL`](https://opensource.posit.co/blog/2026-04-14_chrome-headless-shell/) which natively supports Linux ARM64 and AMD64 builds. Shared system libraries required by `CHROME HEADLESS SHELL` have also been added. These additions have remediated the cryptic `AssertionError` (as reported in the issue) when attempting to render the Quarto document.

## Testing

Check out the PR and rebuild the container using the refined Dockerfile. To generate the example Quarto document, run `quarto render` from the terminal.