### PR TITLE
Publish dev base image to ghcr.io and slim template Dockerfile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 // https://github.com/rocker-org/devcontainer-features
 {
 	"name": "My Awesome Report",
-	"build": {
-		"dockerfile": "../Dockerfile",
-		"target": "dev"
-	},
+	// Pull the pre-built base image from ghcr.io instead of building it
+	// locally. The image is published by .github/workflows/publish-image.yml.
+	// Requires the ghcr.io package to be public (or `docker login ghcr.io`).
+	"image": "ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest",
 
 	// Install the `arf` R terminal and R packages for developing in VScode.
 	// Run as a single sequential script (rather than the object form, whose

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -28,19 +28,19 @@ jobs:
       packages: write
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # QEMU + Buildx are required to build the arm64 image on an amd64 runner.
       # The base is multi-arch (see TARGETARCH in Dockerfile.base); without
       # these steps we would silently publish an amd64-only image.
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Extract image metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/ketchbrookanalytics/quarto-pdf-dev
           tags: |
@@ -56,7 +56,7 @@ jobs:
             type=sha
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.base

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,68 @@
+name: Publish base image
+
+# Builds Dockerfile.base and pushes it to
+# ghcr.io/ketchbrookanalytics/quarto-pdf-dev. New repos created from this
+# template pull that image instead of rebuilding the ~60-line base themselves.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # Rebuild when the base definition or this workflow changes.
+      - Dockerfile.base
+      - .github/workflows/publish-image.yml
+  # Allow manual rebuilds (e.g. to publish a fresh base without a code change).
+  workflow_dispatch:
+  # Weekly rebuild so OS/security patches in the base layers stay current.
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  publish:
+    # Only run in the template's source repo, never in repos scaffolded from
+    # it — otherwise every client repo would try to push to the shared base.
+    if: github.repository == 'ketchbrookanalytics/quarto-pdf-dev'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      # QEMU + Buildx are required to build the arm64 image on an amd64 runner.
+      # The base is multi-arch (see TARGETARCH in Dockerfile.base); without
+      # these steps we would silently publish an amd64-only image.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/ketchbrookanalytics/quarto-pdf-dev
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.base
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,7 @@
 # pin this to an immutable digest tag (e.g. ":sha-abc1234"); the publish
 # workflow tags every build with its commit SHA. Do this at handoff, alongside
 # locking renv.lock (see the README's "Pre-Deployment Steps").
-FROM ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest AS dev
-
-# Build upon the dev image (called by the devcontainer) & add prod instructions
-FROM dev AS prod
+FROM ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest
 
 # Set the working directory for the project
 WORKDIR /project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,68 +1,12 @@
-# Define the version of R that we'll be using
-ARG R_VERSION=4.6.0
-
-# Use the rocker/verse base image to install the specific version of R
-FROM rocker/r-ver:${R_VERSION} AS dev
-
-# Define the versions of the other software dependencies we'll be using
-ARG QUARTO_VERSION=1.9.38
-
-# Install fonts, along with the shared libraries that Chrome Headless Shell
-# (installed below) needs at runtime to render mermaid/graphviz diagrams.
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    fonts-roboto \
-    fonts-noto-color-emoji \
-    wget \
-    libnss3 \
-    libnspr4 \
-    libatk1.0-0t64 \
-    libatk-bridge2.0-0t64 \
-    libatspi2.0-0t64 \
-    libdbus-1-3 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxfixes3 \
-    libxrandr2 \
-    libxkbcommon0 \
-    libasound2t64 \
-    libgbm1 \
-    libcups2t64 \
-    libpango-1.0-0 \
-    libcairo2 \
-  && rm -rf /var/lib/apt/lists/*
-
-# Install Quarto, along with Chrome Headless Shell - Quarto's purpose-built
-# headless browser (Chrome for Testing) used to render mermaid/graphviz
-# diagrams. It ships native arm64 and amd64 Linux builds and needs no system
-# Chrome/Chromium package, unlike the apt-based Chrome install this replaced.
-ARG TARGETARCH
-RUN wget -q "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
-  && dpkg -i "quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
-  && rm "quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
-  && quarto install chrome-headless-shell --no-prompt
-
-# Install the latest version of {pak}
-RUN R -q -e "install.packages('pak')"
-
-# Ensure we use {pak} on the backend with {renv} to install the packages in the
-# lock file
-ENV RENV_CONFIG_PAK_ENABLED=true
-
-# Ensure we properly isolate "dev" packages installed in the Dev Container
-ENV RENV_CONFIG_SANDBOX_ENABLED=false
-
-# Don't automatically compare installed packages to lock file every new R
-# session
-ENV RENV_CONFIG_SYNCHRONIZED_CHECK=false
-
-# Define the version of {renv} to install
-ARG RENV_VERSION=1.2.3
-
-# Install {renv}
-# Note that we won't use {renv} to install packages during development;
-# conversely, we'll use {pak}. We'll only use {renv} during the pre-deployment
-# process (see README for further instructions).
-RUN R -q -e "pak::pkg_install('rstudio/renv@v${RENV_VERSION}')"
+# The reusable "dev" base image (R + Quarto + Chrome Headless Shell + pak +
+# renv) is pre-built from Dockerfile.base and published to ghcr.io by
+# .github/workflows/publish-image.yml, so new repos no longer rebuild it.
+#
+# ":latest" always tracks the newest base. For a fully reproducible build,
+# pin this to an immutable digest tag (e.g. ":sha-abc1234"); the publish
+# workflow tags every build with its commit SHA. Do this at handoff, alongside
+# locking renv.lock (see the README's "Pre-Deployment Steps").
+FROM ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest AS dev
 
 # Build upon the dev image (called by the devcontainer) & add prod instructions
 FROM dev AS prod

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,71 @@
+# This is the reusable base ("dev") image, published to
+# ghcr.io/ketchbrookanalytics/quarto-pdf-dev by
+# .github/workflows/publish-image.yml. It is intentionally project-agnostic:
+# the project-specific "prod" stage lives in the root Dockerfile and builds
+# FROM this image.
+
+# Define the version of R that we'll be using
+ARG R_VERSION=4.6.0
+
+# Use the rocker/verse base image to install the specific version of R
+FROM rocker/r-ver:${R_VERSION} AS dev
+
+# Define the versions of the other software dependencies we'll be using
+ARG QUARTO_VERSION=1.9.38
+
+# Install fonts, along with the shared libraries that Chrome Headless Shell
+# (installed below) needs at runtime to render mermaid/graphviz diagrams.
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    fonts-roboto \
+    fonts-noto-color-emoji \
+    wget \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0t64 \
+    libatk-bridge2.0-0t64 \
+    libatspi2.0-0t64 \
+    libdbus-1-3 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libxkbcommon0 \
+    libasound2t64 \
+    libgbm1 \
+    libcups2t64 \
+    libpango-1.0-0 \
+    libcairo2 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Quarto, along with Chrome Headless Shell - Quarto's purpose-built
+# headless browser (Chrome for Testing) used to render mermaid/graphviz
+# diagrams. It ships native arm64 and amd64 Linux builds and needs no system
+# Chrome/Chromium package, unlike the apt-based Chrome install this replaced.
+ARG TARGETARCH
+RUN wget -q "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
+  && dpkg -i "quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
+  && rm "quarto-${QUARTO_VERSION}-linux-${TARGETARCH}.deb" \
+  && quarto install chrome-headless-shell --no-prompt
+
+# Install the latest version of {pak}
+RUN R -q -e "install.packages('pak')"
+
+# Ensure we use {pak} on the backend with {renv} to install the packages in the
+# lock file
+ENV RENV_CONFIG_PAK_ENABLED=true
+
+# Ensure we properly isolate "dev" packages installed in the Dev Container
+ENV RENV_CONFIG_SANDBOX_ENABLED=false
+
+# Don't automatically compare installed packages to lock file every new R
+# session
+ENV RENV_CONFIG_SYNCHRONIZED_CHECK=false
+
+# Define the version of {renv} to install
+ARG RENV_VERSION=1.2.3
+
+# Install {renv}
+# Note that we won't use {renv} to install packages during development;
+# conversely, we'll use {pak}. We'll only use {renv} during the pre-deployment
+# process (see README for further instructions).
+RUN R -q -e "pak::pkg_install('rstudio/renv@v${RENV_VERSION}')"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you don't see the popup, you can also reopen in container via the VSCode Comm
 - Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on Mac) to open the Command Palette.
 - Search for "Dev Containers: Reopen in Container" and select it.
 
-This will build the Docker image locally (which will take a few minutes the first time you do this) and then spin up a Docker container that will serve as your development environment in VSCode. You can continue working in VSCode as you normally would! If you make changes to any of the files in the [.devcontainer/](.devcontainer/) directory, you will need to rebuild the image.
+This will pull the pre-built base image from `ghcr.io/ketchbrookanalytics/quarto-pdf-dev` (which will take a minute the first time you do this) and then spin up a Docker container that will serve as your development environment in VSCode. You can continue working in VSCode as you normally would! If you make changes to any of the files in the [.devcontainer/](.devcontainer/) directory, you will need to rebuild the container.
 
 ### Why Devcontainers?
 
@@ -84,6 +84,8 @@ renv::snapshot()
 
 The resulting `renv.lock` file will be used by Docker during build time to install the exact R package dependencies used in the project via `renv::restore()`.
 
+For a *fully* reproducible build, also pin the base image at this point. The `dev` stage of the [Dockerfile](Dockerfile) references `ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest`, which tracks the newest base. Replace `:latest` with the immutable `:sha-...` tag of a specific published base (visible on the [package page](https://github.com/ketchbrookanalytics/quarto-pdf-dev/pkgs/container/quarto-pdf-dev)) so the R/Quarto versions can't drift after handoff.
+
 Commit and push the changes to the repository. You're now ready to hand off this repository to others who want to reproduce your work.
 
 ## Reproduction
@@ -137,5 +139,6 @@ This repository contains the following components:
 - [qmd/](qmd/) contains the [Quarto child documents](https://quarto.org/docs/authoring/includes.html) that make up most of the report narrative and detail.
 - [_quarto.yml](_quarto.yml) specifies the different [options](https://quarto.org/docs/reference/formats/typst.html) Quarto provides for rendering Typst PDF documents, and also passes variables to [typst-show.typ](assets/typst-show.typ) which, in turn, passes values to [typst-template.typ](assets/typst-template.typ).
 - [air.toml](air.toml) instantiates the project's use of [Air](https://posit-dev.github.io/air/) for R code formatting.
-- [Dockerfile](Dockerfile) serves as the base Docker image that [devcontainer.json](.devcontainer/devcontainer.json) builds upon, as well as additional *prod* dependencies for deployment purposes at the conclusion of the project. It contains the major dependencies (R, Quarto, and Chrome) needed for the project.
+- [Dockerfile.base](Dockerfile.base) defines the reusable `dev` base image (R, Quarto, Chrome Headless Shell, `pak`, `renv`). It is published to `ghcr.io/ketchbrookanalytics/quarto-pdf-dev` by [.github/workflows/publish-image.yml](.github/workflows/publish-image.yml) and is shared, unchanged, across every report project.
+- [Dockerfile](Dockerfile) pulls that published base image as its `dev` stage and adds the project-specific *prod* stage (assets, `qmd/`, `renv::restore()`) used for deployment at the conclusion of the project.
 - [report.qmd](report.qmd) is an example Quarto report that showcases how to include tables, plots, and diagrams.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The devcontainer also offers the following additional features:
 
 ### Pre-Deployment Steps
 
-Before you formally handoff your work to someone else, you'll want to use {renv} to lock down the versions of the R packages you used (as evidenced in the `prod` stage of the multi-stage build in the [Dockerfile](Dockerfile)) so that the work is *fully reproducible*. In order to do so, run the following commands in an R terminal:
+Before you formally handoff your work to someone else, you'll want to use {renv} to lock down the versions of the R packages you used (installed via `renv::restore()` in the [Dockerfile](Dockerfile)) so that the work is *fully reproducible*. In order to do so, run the following commands in an R terminal:
 
 ```r
 # Initialize {renv}
@@ -84,7 +84,7 @@ renv::snapshot()
 
 The resulting `renv.lock` file will be used by Docker during build time to install the exact R package dependencies used in the project via `renv::restore()`.
 
-For a *fully* reproducible build, also pin the base image at this point. The `dev` stage of the [Dockerfile](Dockerfile) references `ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest`, which tracks the newest base. Replace `:latest` with the immutable `:sha-...` tag of a specific published base (visible on the [package page](https://github.com/ketchbrookanalytics/quarto-pdf-dev/pkgs/container/quarto-pdf-dev)) so the R/Quarto versions can't drift after handoff.
+For a *fully* reproducible build, also pin the base image at this point. The [Dockerfile](Dockerfile) references `ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest`, which tracks the newest base. Replace `:latest` with the immutable `:sha-...` tag of a specific published base (visible on the [package page](https://github.com/ketchbrookanalytics/quarto-pdf-dev/pkgs/container/quarto-pdf-dev)) so the R/Quarto versions can't drift after handoff.
 
 Commit and push the changes to the repository. You're now ready to hand off this repository to others who want to reproduce your work.
 
@@ -107,10 +107,10 @@ Steps 3 and 4 are further explained below.
 In order to build the Docker image that contains all of the project's dependencies, run the following command from a bash/shell terminal:
 
 ```bash
-docker build --target prod -t ketchbrook/report .
+docker build -t ketchbrook/report .
 ```
 
-The above command builds the *prod* Docker image from the specified `Dockerfile`, and tags it with a name you can use later, such as `ketchbrook/report`.
+The above command builds the deployment Docker image from the specified `Dockerfile`, and tags it with a name you can use later, such as `ketchbrook/report`.
 
 ### Run the Docker Container
 
@@ -140,5 +140,5 @@ This repository contains the following components:
 - [_quarto.yml](_quarto.yml) specifies the different [options](https://quarto.org/docs/reference/formats/typst.html) Quarto provides for rendering Typst PDF documents, and also passes variables to [typst-show.typ](assets/typst-show.typ) which, in turn, passes values to [typst-template.typ](assets/typst-template.typ).
 - [air.toml](air.toml) instantiates the project's use of [Air](https://posit-dev.github.io/air/) for R code formatting.
 - [Dockerfile.base](Dockerfile.base) defines the reusable `dev` base image (R, Quarto, Chrome Headless Shell, `pak`, `renv`). It is published to `ghcr.io/ketchbrookanalytics/quarto-pdf-dev` by [.github/workflows/publish-image.yml](.github/workflows/publish-image.yml) and is shared, unchanged, across every report project.
-- [Dockerfile](Dockerfile) pulls that published base image as its `dev` stage and adds the project-specific *prod* stage (assets, `qmd/`, `renv::restore()`) used for deployment at the conclusion of the project.
+- [Dockerfile](Dockerfile) builds the project-specific deployment image directly on top of that published base (adding `assets/`, `qmd/`, `renv::restore()`, etc.) at the conclusion of the project.
 - [report.qmd](report.qmd) is an example Quarto report that showcases how to include tables, plots, and diagrams.


### PR DESCRIPTION
Implements #18 — publishes the reusable `dev` base image to ghcr.io and slims the template's Dockerfile down to the project-specific `prod` stage.

## Changes (as planned in #18)
- **`Dockerfile.base`** (new) — the current `dev` stage contents, verbatim.
- **`Dockerfile`** — `dev` stage replaced with `FROM ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest AS dev`; `prod` stage unchanged.
- **`.github/workflows/publish-image.yml`** (new) — builds `Dockerfile.base` and pushes to ghcr.io on push to `main` (path-filtered), tagged `latest` + commit SHA.
- **`.devcontainer/devcontainer.json`** — pulls the image instead of building locally.

## Deviations from the original plan (see issue comment for rationale)
- **Multi-arch build** — QEMU + Buildx + `platforms: linux/amd64,linux/arm64`. A plain `build-push-action` would publish an **amd64-only** base, regressing the arm64/amd64 support just merged in #17.
- **Repo guard** — `if: github.repository == 'ketchbrookanalytics/quarto-pdf-dev'`. This workflow is copied into every repo scaffolded from the template; the guard stops it from ever running (and clobbering the shared base) there.
- **`workflow_dispatch` + weekly `schedule`** — lets the base be rebuilt for OS/security patches without a no-op edit to `Dockerfile.base`.
- **`metadata-action`** — publishes `latest` **and** an immutable `sha-<commit>` tag; README now documents pinning to the SHA tag at handoff (alongside `renv.lock`) for reproducible reports.
- **README** — updated for the pull-based dev flow and base-image pinning.

## ⚠️ Required manual steps after merge (bootstrap ordering)
1. Merge → the workflow runs on `main` and publishes the image for the first time.
2. **Make the ghcr.io package public** (packages default to private) — otherwise the public template's devcontainer/`prod` pulls fail without `docker login`.
3. Then the last acceptance criterion (a fresh repo has a working dev container and can render) can be verified.

## Open decision
The template's `FROM`/devcontainer default to `:latest`. I chose that because it's the only tag guaranteed to exist immediately post-merge and it gives fresh scaffolds the newest base; reproducibility is handled by pinning the `sha-` tag at handoff. Happy to flip the default to a pinned tag if you'd rather scaffolds pin from the start.

## Testing
Not built locally (multi-arch push needs the ghcr package + runner). YAML/Dockerfile line endings verified stored as LF for the Linux runner. First real validation happens when the workflow runs on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
