### PR TITLE
Revert to R 4.5.2 and formalize release tagging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
-# Force LF regardless of platform/core.autocrlf so this script bind-mounted into
-# the (Linux) dev container never gets checked out with CRLF endings.
-.devcontainer/postCreate.sh text eol=lf
+# Force LF regardless of platform/core.autocrlf. These scripts are bind-mounted
+# into a Linux container (the dev container, and the CI smoke test) and must
+# never be checked out with CRLF endings.
+*.sh text eol=lf

--- a/.github/scripts/smoke-test.sh
+++ b/.github/scripts/smoke-test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Smoke-test the "dev" base image by rendering the example report inside it, the
+# way a brand-new user would. Run from the repository root, in a container built
+# from Dockerfile.base:
+#
+#   docker run --rm -v "$PWD:/project" -w /project <image> \
+#     bash .github/scripts/smoke-test.sh
+#
+# Rendering report.qmd exercises nearly everything the base image adds on top of
+# R: {pak} installing packages (with its own apt-get sysreqs pass), the knitr
+# engine, Quarto's Typst PDF backend, Chrome Headless Shell for the mermaid
+# diagrams in qmd/_03_diagrams.qmd, and the Roboto and colour-emoji fonts that
+# report.qmd and the {gt} tables ask for. A build that succeeds but produces an
+# image where any of that is broken fails here instead of in a devcontainer.
+#
+# This script writes to the working tree (_output/, _targets/objects/, .quarto/),
+# all of which are git-ignored.
+set -euo pipefail
+
+# Keep in sync with the "r-packages" arguments to postCreate.sh in
+# .devcontainer/devcontainer.json. The dev-only packages listed there (httpgd,
+# languageserver) are omitted; knitr and rmarkdown are named explicitly because
+# Quarto's knitr engine needs them and the devcontainer only gets them
+# transitively.
+PACKAGES="'ggplot2', 'gt', 'knitr', 'rmarkdown', 'targets', 'tibble'"
+
+echo "==> Versions"
+R --version | head -1
+echo "Quarto $(quarto --version)"
+
+echo "==> Installing R packages via pak"
+R -q -e "pak::pkg_install(c(${PACKAGES}))"
+
+echo "==> Rendering report.qmd"
+# The pre-render hook in _quarto.yml runs targets::tar_make() first, building
+# the {gt} table and {ggplot2} plot that the report reads back with tar_read().
+# _targets/objects/ is git-ignored, so this always rebuilds from scratch here.
+quarto render report.qmd
+
+echo "==> Verifying output"
+PDF=_output/report.pdf
+
+if [ ! -f "$PDF" ]; then
+  echo "FAIL: $PDF was not created"
+  exit 1
+fi
+
+# Check the magic bytes and size rather than mere existence: a Typst backend
+# that half-failed could still leave a stub file behind.
+if ! head -c 4 "$PDF" | grep -qa '%PDF'; then
+  echo "FAIL: $PDF exists but is not a PDF"
+  exit 1
+fi
+
+bytes=$(wc -c < "$PDF")
+if [ "$bytes" -lt 20000 ]; then
+  echo "FAIL: $PDF is only ${bytes} bytes; expected a multi-page report"
+  exit 1
+fi
+
+echo "==> OK: rendered $PDF (${bytes} bytes)"

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -79,5 +79,24 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+          # The weekly run must build from scratch. With the cache enabled it
+          # restored every layer -- including `apt-get install` -- and finished in
+          # 33s, so no OS/security patches ever landed and the "rebuild" only
+          # republished the same layers under a fresh timestamp label. Building
+          # cache-less also re-validates that the base builds the way a brand-new
+          # user builds it: if an external download (the Quarto .deb, an apt
+          # package) stops resolving, the weekly run fails loudly instead of
+          # sailing through on cached layers while `latest` quietly rots.
+          #
+          # Push and manual builds keep the cache, where fast iteration on
+          # Dockerfile.base matters more than freshness.
+          no-cache: ${{ github.event_name == 'schedule' }}
+          # Re-resolve rocker/r-ver rather than trusting a cached parent.
+          pull: ${{ github.event_name == 'schedule' }}
+          # `no-cache` already suppresses cache imports; set explicitly so the
+          # intent survives future edits. Note the inverted condition -- an
+          # expression of the form `cond && '' || 'x'` always yields 'x', since
+          # the empty string is falsy.
+          cache-from: ${{ github.event_name != 'schedule' && 'type=gha' || '' }}
+          # Always export, so the next push build starts from patched layers.
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -11,6 +11,12 @@ on:
       # Rebuild when the base definition or this workflow changes.
       - Dockerfile.base
       - .github/workflows/publish-image.yml
+  # Publishing a GitHub Release (tagged "vX.Y.Z") stamps the image with
+  # immutable semver tags. This is a `release` trigger rather than a `push` tag
+  # filter on purpose: the `paths` filter above would otherwise also apply to
+  # tag pushes and silently skip releases that don't touch Dockerfile.base.
+  release:
+    types: [published]
   # Allow manual rebuilds (e.g. to publish a fresh base without a code change).
   workflow_dispatch:
   # Weekly rebuild so OS/security patches in the base layers stay current.
@@ -51,7 +57,16 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/ketchbrookanalytics/quarto-pdf-dev
+          # Tagging scheme (see the README's "Versioning & Releases"):
+          #   0.2.0 / v0.2.0 - immutable release pin; what handoffs should use
+          #   0.2            - floating minor line; picks up patch re-releases
+          #   latest         - rolling build of main, incl. weekly OS patches
+          #   sha-<commit>   - every build, for tracing an image to a commit
+          # The semver entries are no-ops unless the ref is a "vX.Y.Z" tag.
           tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -112,15 +112,55 @@ jobs:
       # preventing one: `latest` will already have moved. Gating the promotion
       # of `latest` on this step would mean pushing only the `sha-` tag here and
       # promoting with `docker buildx imagetools create` once the test passes.
-      #
-      # Only the runner's own architecture (amd64) is exercised. The arm64
-      # variant could be tested through the QEMU layer set up above, but
-      # installing R packages under emulation is slow enough to not be worth it.
-      - name: Smoke-test the published image
+      - name: Smoke-test the published image (amd64)
+        timeout-minutes: 20
         env:
           IMAGE: ghcr.io/ketchbrookanalytics/quarto-pdf-dev@${{ steps.build.outputs.digest }}
         run: |
           docker run --rm \
+            --platform linux/amd64 \
+            --volume "$PWD:/project" \
+            --workdir /project \
+            "$IMAGE" \
+            bash .github/scripts/smoke-test.sh
+
+      # The amd64 run leaves root-owned build products in the workspace. Clear
+      # them from inside a container, since the runner user can't delete files
+      # owned by root, so the arm64 run below genuinely rebuilds: a populated
+      # _targets/objects/ would make the pre-render hook skip tar_make() (losing
+      # the {gt} and {ggplot2} coverage that is much of the point of testing the
+      # second architecture), and a leftover report.pdf could let a render that
+      # produced nothing still satisfy the script's assertions.
+      - name: Reset the workspace between architectures
+        if: github.event_name == 'schedule' || github.event_name == 'release'
+        env:
+          IMAGE: ghcr.io/ketchbrookanalytics/quarto-pdf-dev@${{ steps.build.outputs.digest }}
+        run: |
+          docker run --rm \
+            --platform linux/amd64 \
+            --volume "$PWD:/project" \
+            --workdir /project \
+            "$IMAGE" \
+            rm -rf _output .quarto _targets/objects
+
+      # Same test, same script, arm64 -- through the QEMU layer set up above.
+      # Restricted to scheduled and release runs: pushes to main already get
+      # amd64 coverage for fast feedback, and these are the runs whose output
+      # actually reaches a devcontainer or gets pinned at handoff.
+      #
+      # Emulation is the whole cost here, not compilation: P3M serves prebuilt
+      # aarch64 binaries for noble, so pak installs are downloads on both
+      # architectures. The slow, and most failure-prone, part is Chrome Headless
+      # Shell rendering the mermaid diagrams under QEMU -- hence the timeout, so
+      # a hang fails the job instead of burning the runner's full allowance.
+      - name: Smoke-test the published image (arm64)
+        if: github.event_name == 'schedule' || github.event_name == 'release'
+        timeout-minutes: 45
+        env:
+          IMAGE: ghcr.io/ketchbrookanalytics/quarto-pdf-dev@${{ steps.build.outputs.digest }}
+        run: |
+          docker run --rm \
+            --platform linux/arm64 \
             --volume "$PWD:/project" \
             --workdir /project \
             "$IMAGE" \

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -62,23 +62,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # This job pushes ONLY the sha- tag. The user-facing tags (latest and the
+      # semver lines) are applied by the `promote` job, after the smoke test
+      # passes, so a broken image can never become anyone's `latest`. Tagging
+      # scheme, in full, is in the README's "Versioning & Releases".
+      #
+      # Consequence worth knowing: a sha- tag exists for every build, including
+      # ones that fail the smoke test. Pinning a sha- tag means pinning something
+      # possibly untested -- pin a released vX.Y.Z instead.
       - name: Extract image metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/ketchbrookanalytics/quarto-pdf-dev
-          # Tagging scheme (see the README's "Versioning & Releases"):
-          #   0.2.0 / v0.2.0 - immutable release pin; what handoffs should use
-          #   0.2            - floating minor line; picks up patch re-releases
-          #   latest         - rolling build of main, incl. weekly OS patches
-          #   sha-<commit>   - every build, for tracing an image to a commit
-          # The semver entries are no-ops unless the ref is a "vX.Y.Z" tag.
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern=v{{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha
+          tags: type=sha
 
       - name: Build and push
         id: build
@@ -113,15 +110,11 @@ jobs:
           cache-to: type=gha,mode=max
 
   # A green build only proves the image assembled, not that anyone can use it.
-  # Render the example report inside the image that was just published, pulled
-  # back by digest so this tests the exact artifact users pull rather than a
+  # Render the example report inside the image that was just pushed, pulled back
+  # by digest so this tests the exact artifact users will pull rather than a
   # separate local build. See .github/scripts/smoke-test.sh for what the render
-  # covers.
-  #
-  # This runs after the push, so it detects a broken image rather than
-  # preventing one: `latest` will already have moved. Gating the promotion of
-  # `latest` on it would mean pushing only the `sha-` tag from the job above and
-  # promoting with `docker buildx imagetools create` once this job passes.
+  # covers. This job gates `promote` below, so a failure here leaves `latest`
+  # pointing at the last image that did pass.
   smoke:
     needs: publish
     permissions:
@@ -138,18 +131,22 @@ jobs:
     # of the second one inheriting built targets and a rendered PDF from the
     # first.
     #
-    # arm64 joins the matrix only on scheduled and release runs -- the runs whose
-    # output reaches a devcontainer or gets pinned at handoff. Pushes to main
-    # keep fast amd64-only feedback. Unlike the `cache-from` expression above,
-    # both branches here are non-empty strings, so `cond && A || B` is safe.
+    # Both architectures run on every build. Native arm64 runners are free for
+    # public repositories and no slower than amd64, so there is nothing to save
+    # by testing only one -- and since this job now gates promotion, testing one
+    # architecture would mean promoting `latest` for an architecture nobody
+    # checked.
+    #
+    # fail-fast is off so a single-architecture failure still reports the other
+    # one's result; either failure blocks promotion.
     strategy:
       fail-fast: false
-      matrix: >-
-        ${{ fromJSON(
-          (github.event_name == 'schedule' || github.event_name == 'release')
-          && '{"include":[{"arch":"amd64","runner":"ubuntu-latest"},{"arch":"arm64","runner":"ubuntu-24.04-arm"}]}'
-          || '{"include":[{"arch":"amd64","runner":"ubuntu-latest"}]}'
-        ) }}
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out the repository
@@ -165,3 +162,74 @@ jobs:
             --workdir /project \
             "$IMAGE" \
             bash .github/scripts/smoke-test.sh
+
+  # Only now, with both architectures proven to render, do the tags anyone
+  # actually pulls start pointing at this build. `imagetools create` copies the
+  # existing multi-arch index (attestations included) under new tags -- it is a
+  # registry-side manifest operation, so nothing is rebuilt or re-uploaded.
+  #
+  # Because this job is what moves `latest`, a smoke-test failure leaves users on
+  # the last image that passed. The trade-off is that `latest` lags a failing
+  # build rather than tracking HEAD, which is the point.
+  promote:
+    needs: [publish, smoke]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # The semver entries are no-ops unless the ref is a "vX.Y.Z" tag, and
+      # `latest` only applies on the default branch -- so a release run promotes
+      # the version tags and a push to main promotes `latest`.
+      - name: Work out which tags to promote
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/ketchbrookanalytics/quarto-pdf-dev
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Promote the tested image
+        env:
+          # Newline-separated, passed through the environment rather than
+          # interpolated into the script, so tag values can't break quoting.
+          TAGS: ${{ steps.meta.outputs.tags }}
+          SOURCE: ghcr.io/ketchbrookanalytics/quarto-pdf-dev@${{ needs.publish.outputs.digest }}
+        run: |
+          tags=()
+          while IFS= read -r tag; do
+            # An `if` rather than `[ -n "$tag" ] && ...`: the && form returns
+            # non-zero on the blank line, and these steps run under `bash -e`.
+            if [ -n "$tag" ]; then
+              tags+=("$tag")
+            fi
+          done <<< "$TAGS"
+
+          # Nothing to promote when neither rule matched -- e.g. a manual run on
+          # a non-default branch, which should stay reachable only by sha- tag.
+          if [ "${#tags[@]}" -eq 0 ]; then
+            echo "No promotion tags for this ref; leaving the sha- tag as the only reference."
+            exit 0
+          fi
+
+          args=()
+          for tag in "${tags[@]}"; do
+            args+=(--tag "$tag")
+          done
+
+          docker buildx imagetools create "${args[@]}" "$SOURCE"
+          echo "Promoted $SOURCE to:"
+          printf '  %s\n' "${tags[@]}"

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -145,6 +145,7 @@ jobs:
         include:
           - arch: amd64
             runner: ubuntu-latest
+            # Currently, ARM64 runners are version-pinned (there's no `ubuntu-latest` available)
           - arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -71,6 +71,7 @@ jobs:
             type=sha
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -100,3 +101,27 @@ jobs:
           cache-from: ${{ github.event_name != 'schedule' && 'type=gha' || '' }}
           # Always export, so the next push build starts from patched layers.
           cache-to: type=gha,mode=max
+
+      # A green build only proves the image assembled, not that anyone can use
+      # it. Render the example report inside the image we just published --
+      # pulled back by digest, so this tests the exact artifact users pull, not
+      # a separate local build. See .github/scripts/smoke-test.sh for what the
+      # render covers.
+      #
+      # This runs after the push, so it detects a broken image rather than
+      # preventing one: `latest` will already have moved. Gating the promotion
+      # of `latest` on this step would mean pushing only the `sha-` tag here and
+      # promoting with `docker buildx imagetools create` once the test passes.
+      #
+      # Only the runner's own architecture (amd64) is exercised. The arm64
+      # variant could be tested through the QEMU layer set up above, but
+      # installing R packages under emulation is slow enough to not be worth it.
+      - name: Smoke-test the published image
+        env:
+          IMAGE: ghcr.io/ketchbrookanalytics/quarto-pdf-dev@${{ steps.build.outputs.digest }}
+        run: |
+          docker run --rm \
+            --volume "$PWD:/project" \
+            --workdir /project \
+            "$IMAGE" \
+            bash .github/scripts/smoke-test.sh

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -32,6 +32,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    # Consumed by the `smoke` job below, so it tests this exact build rather
+    # than whatever `latest` happens to point at by the time it runs.
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v7
@@ -39,6 +43,12 @@ jobs:
       # QEMU + Buildx are required to build the arm64 image on an amd64 runner.
       # The base is multi-arch (see TARGETARCH in Dockerfile.base); without
       # these steps we would silently publish an amd64-only image.
+      #
+      # Emulation is fine for *building* -- apt, the Quarto .deb, and the R
+      # package installs all work under QEMU. It is only Chrome at runtime that
+      # doesn't, which is why the `smoke` job below uses native runners instead.
+      # Splitting the build across a native runner per architecture and merging
+      # the manifests would be faster still, but that is a larger change.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
@@ -102,65 +112,55 @@ jobs:
           # Always export, so the next push build starts from patched layers.
           cache-to: type=gha,mode=max
 
-      # A green build only proves the image assembled, not that anyone can use
-      # it. Render the example report inside the image we just published --
-      # pulled back by digest, so this tests the exact artifact users pull, not
-      # a separate local build. See .github/scripts/smoke-test.sh for what the
-      # render covers.
-      #
-      # This runs after the push, so it detects a broken image rather than
-      # preventing one: `latest` will already have moved. Gating the promotion
-      # of `latest` on this step would mean pushing only the `sha-` tag here and
-      # promoting with `docker buildx imagetools create` once the test passes.
-      - name: Smoke-test the published image (amd64)
-        timeout-minutes: 20
-        env:
-          IMAGE: ghcr.io/ketchbrookanalytics/quarto-pdf-dev@${{ steps.build.outputs.digest }}
-        run: |
-          docker run --rm \
-            --platform linux/amd64 \
-            --volume "$PWD:/project" \
-            --workdir /project \
-            "$IMAGE" \
-            bash .github/scripts/smoke-test.sh
+  # A green build only proves the image assembled, not that anyone can use it.
+  # Render the example report inside the image that was just published, pulled
+  # back by digest so this tests the exact artifact users pull rather than a
+  # separate local build. See .github/scripts/smoke-test.sh for what the render
+  # covers.
+  #
+  # This runs after the push, so it detects a broken image rather than
+  # preventing one: `latest` will already have moved. Gating the promotion of
+  # `latest` on it would mean pushing only the `sha-` tag from the job above and
+  # promoting with `docker buildx imagetools create` once this job passes.
+  smoke:
+    needs: publish
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    # Each architecture tests on its own native runner, not through the QEMU
+    # layer the build uses. That is not a preference: rendering under emulation
+    # dies where Quarto drives Chrome Headless Shell ("AssertionError ... Child
+    # process has already terminated"), while the identical render with the
+    # mermaid diagrams removed passes, so the emulation layer breaks Chrome, not
+    # the arm64 image. Public repositories get ubuntu-24.04-arm runners at no
+    # cost, so test on real hardware rather than working around QEMU. Separate
+    # runners also mean each architecture starts from a clean workspace, instead
+    # of the second one inheriting built targets and a rendered PDF from the
+    # first.
+    #
+    # arm64 joins the matrix only on scheduled and release runs -- the runs whose
+    # output reaches a devcontainer or gets pinned at handoff. Pushes to main
+    # keep fast amd64-only feedback. Unlike the `cache-from` expression above,
+    # both branches here are non-empty strings, so `cond && A || B` is safe.
+    strategy:
+      fail-fast: false
+      matrix: >-
+        ${{ fromJSON(
+          (github.event_name == 'schedule' || github.event_name == 'release')
+          && '{"include":[{"arch":"amd64","runner":"ubuntu-latest"},{"arch":"arm64","runner":"ubuntu-24.04-arm"}]}'
+          || '{"include":[{"arch":"amd64","runner":"ubuntu-latest"}]}'
+        ) }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7
 
-      # The amd64 run leaves root-owned build products in the workspace. Clear
-      # them from inside a container, since the runner user can't delete files
-      # owned by root, so the arm64 run below genuinely rebuilds: a populated
-      # _targets/objects/ would make the pre-render hook skip tar_make() (losing
-      # the {gt} and {ggplot2} coverage that is much of the point of testing the
-      # second architecture), and a leftover report.pdf could let a render that
-      # produced nothing still satisfy the script's assertions.
-      - name: Reset the workspace between architectures
-        if: github.event_name == 'schedule' || github.event_name == 'release'
+      - name: Render report.qmd inside the published image
         env:
-          IMAGE: ghcr.io/ketchbrookanalytics/quarto-pdf-dev@${{ steps.build.outputs.digest }}
+          IMAGE: ghcr.io/ketchbrookanalytics/quarto-pdf-dev@${{ needs.publish.outputs.digest }}
         run: |
           docker run --rm \
-            --platform linux/amd64 \
-            --volume "$PWD:/project" \
-            --workdir /project \
-            "$IMAGE" \
-            rm -rf _output .quarto _targets/objects
-
-      # Same test, same script, arm64 -- through the QEMU layer set up above.
-      # Restricted to scheduled and release runs: pushes to main already get
-      # amd64 coverage for fast feedback, and these are the runs whose output
-      # actually reaches a devcontainer or gets pinned at handoff.
-      #
-      # Emulation is the whole cost here, not compilation: P3M serves prebuilt
-      # aarch64 binaries for noble, so pak installs are downloads on both
-      # architectures. The slow, and most failure-prone, part is Chrome Headless
-      # Shell rendering the mermaid diagrams under QEMU -- hence the timeout, so
-      # a hang fails the job instead of burning the runner's full allowance.
-      - name: Smoke-test the published image (arm64)
-        if: github.event_name == 'schedule' || github.event_name == 'release'
-        timeout-minutes: 45
-        env:
-          IMAGE: ghcr.io/ketchbrookanalytics/quarto-pdf-dev@${{ steps.build.outputs.digest }}
-        run: |
-          docker run --rm \
-            --platform linux/arm64 \
+            --platform linux/${{ matrix.arch }} \
             --volume "$PWD:/project" \
             --workdir /project \
             "$IMAGE" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Dependency stack: **R 4.5.2**, **Quarto 1.9.38**, **`{renv}` 1.2.3**
   base image with immutable `X.Y.Z` / `vX.Y.Z` tags plus a floating `X.Y` minor
   line, so a handoff can pin a known-good dependency stack by version instead of
   by commit SHA.
+- A smoke test ([.github/scripts/smoke-test.sh](.github/scripts/smoke-test.sh))
+  that renders [report.qmd](report.qmd) inside every published base image, so a
+  build that assembles but can't actually render fails in CI rather than in
+  someone's devcontainer. The render covers `{pak}`, the knitr engine, Quarto's
+  Typst backend, Chrome Headless Shell (the mermaid diagrams), and the Roboto and
+  emoji fonts.
 - Multi-architecture base image (`linux/amd64` and `linux/arm64`), built with
   QEMU + Buildx.
 - Chrome Headless Shell, installed via `quarto install`, so mermaid and graphviz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ Dependency stack: **R 4.5.2**, **Quarto 1.9.38**, **`{renv}` 1.2.3**
   someone's devcontainer. The render covers `{pak}`, the knitr engine, Quarto's
   Typst backend, Chrome Headless Shell (the mermaid diagrams), and the Roboto and
   emoji fonts. Every run tests `linux/amd64`; scheduled and release runs also
-  test `linux/arm64` through QEMU, so the architecture that reaches Apple Silicon
-  devcontainers is exercised before anyone pins it.
+  test `linux/arm64`, so the architecture that reaches Apple Silicon
+  devcontainers is exercised before anyone pins it. Each architecture runs on a
+  native runner rather than through the QEMU layer used to build it, because
+  Chrome Headless Shell cannot render under emulation.
 - Multi-architecture base image (`linux/amd64` and `linux/arm64`), built with
   QEMU + Buildx.
 - Chrome Headless Shell, installed via `quarto install`, so mermaid and graphviz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+All notable changes to this template are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to the versioning policy documented in the
+[README](README.md#versioning--releases).
+
+Because the pinned dependency stack (R, Quarto, `{renv}`) *is* the product here,
+every release note calls out the versions it ships.
+
+## [Unreleased]
+
+Dependency stack: **R 4.5.2**, **Quarto 1.9.38**, **`{renv}` 1.2.3**
+
+### Added
+
+- Reusable `dev` base image, defined in `Dockerfile.base` and published to
+  `ghcr.io/ketchbrookanalytics/quarto-pdf-dev` by
+  [.github/workflows/publish-image.yml](.github/workflows/publish-image.yml).
+  New projects pull the pre-built base instead of rebuilding R and Quarto from
+  scratch. Rebuilt weekly so OS/security patches stay current.
+- Semver release tagging. Publishing a `vX.Y.Z` GitHub Release now stamps the
+  base image with immutable `X.Y.Z` / `vX.Y.Z` tags plus a floating `X.Y` minor
+  line, so a handoff can pin a known-good dependency stack by version instead of
+  by commit SHA.
+- Multi-architecture base image (`linux/amd64` and `linux/arm64`), built with
+  QEMU + Buildx.
+- Chrome Headless Shell, installed via `quarto install`, so mermaid and graphviz
+  diagrams render without a system Chrome/Chromium package.
+- Emoji support in rendered PDFs, via `fonts-noto-color-emoji`.
+- Devcontainer tooling: the [arf](https://github.com/eitsupi/arf) R terminal,
+  [Air](https://posit-dev.github.io/air/) for R code formatting, and the
+  [Claude Code](https://code.claude.com/docs/en/vs-code) VSCode extension.
+- Example report scaffolding: a [{targets}](https://docs.ropensci.org/targets/)
+  pipeline, [Quarto child documents](qmd/), and a `references.bib` bibliography.
+
+### Changed
+
+- **Reverted R from 4.6.0 back to 4.5.2.** R 4.6.0 breaks the vscode-R session
+  watcher, which makes `View()` fail on `{gt}` tables and other HTML widgets
+  inside the devcontainer
+  ([#20](https://github.com/ketchbrookanalytics/quarto-pdf-dev/issues/20),
+  upstream [vscode-R#1696](https://github.com/REditorSupport/vscode-R/issues/1696)).
+  A fix exists in the vscode-R development release; R can move back to 4.6.x once
+  that ships to the marketplace.
+- Bumped `{renv}` to 1.2.3.
+- Collapsed the project `Dockerfile` from a multi-stage build to a single stage
+  built `FROM` the published base image.
+- Bumped the workflow's GitHub Actions to their Node 24 majors.
+- Figures may now break across pages in Typst PDFs.
+
+### Fixed
+
+- `View()` on a `{gt}` table no longer errors with "unable to start data viewer"
+  in the devcontainer (see the R revert above).
+- `arf` and the REditorSupport extension now share a session, so objects created
+  in the `arf` terminal appear in the VSCode R workspace viewer.
+- `arf` and `pak::pkg_install()` no longer run in parallel during
+  `postCreateCommand`, which could race.
+- `PostCreate.sh` is forced to LF line endings, so the devcontainer builds from a
+  Windows clone.
+
+## [0.1.0] - 2026-04-14
+
+Initial release.
+
+[Unreleased]: https://github.com/ketchbrookanalytics/quarto-pdf-dev/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ketchbrookanalytics/quarto-pdf-dev/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ Dependency stack: **R 4.5.2**, **Quarto 1.9.38**, **`{renv}` 1.2.3**
 
 - `View()` on a `{gt}` table no longer errors with "unable to start data viewer"
   in the devcontainer (see the R revert above).
+- The weekly base-image rebuild now actually rebuilds. It was restoring every
+  layer from the GitHub Actions cache -- `apt-get install` included -- and
+  finishing in 33 seconds, so no OS/security patch ever reached the published
+  image despite the manifest digest changing each week. Scheduled runs now build
+  cache-less, which also verifies the base still builds from scratch the way a
+  new user builds it. Push and manual builds keep the cache.
 - `arf` and the REditorSupport extension now share a session, so objects created
   in the `arf` terminal appear in the VSCode R workspace viewer.
 - `arf` and `pak::pkg_install()` no longer run in parallel during

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ Dependency stack: **R 4.5.2**, **Quarto 1.9.38**, **`{renv}` 1.2.3**
   build that assembles but can't actually render fails in CI rather than in
   someone's devcontainer. The render covers `{pak}`, the knitr engine, Quarto's
   Typst backend, Chrome Headless Shell (the mermaid diagrams), and the Roboto and
-  emoji fonts.
+  emoji fonts. Every run tests `linux/amd64`; scheduled and release runs also
+  test `linux/arm64` through QEMU, so the architecture that reaches Apple Silicon
+  devcontainers is exercised before anyone pins it.
 - Multi-architecture base image (`linux/amd64` and `linux/arm64`), built with
   QEMU + Buildx.
 - Chrome Headless Shell, installed via `quarto install`, so mermaid and graphviz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,13 @@ Dependency stack: **R 4.5.2**, **Quarto 1.9.38**, **`{renv}` 1.2.3**
   build that assembles but can't actually render fails in CI rather than in
   someone's devcontainer. The render covers `{pak}`, the knitr engine, Quarto's
   Typst backend, Chrome Headless Shell (the mermaid diagrams), and the Roboto and
-  emoji fonts. Every run tests `linux/amd64`; scheduled and release runs also
-  test `linux/arm64`, so the architecture that reaches Apple Silicon
-  devcontainers is exercised before anyone pins it. Each architecture runs on a
-  native runner rather than through the QEMU layer used to build it, because
-  Chrome Headless Shell cannot render under emulation.
+  emoji fonts. Both `linux/amd64` and `linux/arm64` are tested on every build,
+  each on a native runner rather than through the QEMU layer used to build them,
+  because Chrome Headless Shell cannot render under emulation.
+- The smoke test gates publication. The build pushes only a `sha-` tag; `latest`
+  and the semver tags are moved onto that image by a separate `promote` job once
+  both architectures have rendered the report, so a build that can't render never
+  becomes anyone's `latest`.
 - Multi-architecture base image (`linux/amd64` and `linux/arm64`), built with
   QEMU + Buildx.
 - Chrome Headless Shell, installed via `quarto install`, so mermaid and graphviz

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@
 # renv) is pre-built from Dockerfile.base and published to ghcr.io by
 # .github/workflows/publish-image.yml, so new repos no longer rebuild it.
 #
-# ":latest" always tracks the newest base. For a fully reproducible build,
-# pin this to an immutable digest tag (e.g. ":sha-abc1234"); the publish
-# workflow tags every build with its commit SHA. Do this at handoff, alongside
-# locking renv.lock (see the README's "Pre-Deployment Steps").
+# ":latest" always tracks the newest base, so an in-flight project picks up
+# OS/security patches from the weekly rebuild. For a fully reproducible build,
+# pin this to a released version tag (e.g. ":v0.2.0") at handoff, alongside
+# locking renv.lock. See the README's "Pre-Deployment Steps" and
+# "Versioning & Releases" sections.
 FROM ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest
 
 # Set the working directory for the project

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -4,8 +4,14 @@
 # the project-specific "prod" stage lives in the root Dockerfile and builds
 # FROM this image.
 
-# Define the version of R that we'll be using
-ARG R_VERSION=4.6.0
+# Define the version of R that we'll be using.
+#
+# Pinned to 4.5.x: R 4.6.0 breaks the vscode-R session watcher, so `View()` on a
+# {gt} table (or any HTML widget) fails with "unable to start data viewer" in the
+# devcontainer. See https://github.com/REditorSupport/vscode-R/issues/1696. A fix
+# exists in the vscode-R development release; once it ships to the marketplace,
+# this can move back to 4.6.x.
+ARG R_VERSION=4.5.2
 
 # Use the rocker/verse base image to install the specific version of R
 FROM rocker/r-ver:${R_VERSION} AS dev

--- a/README.md
+++ b/README.md
@@ -148,10 +148,12 @@ The base image at `ghcr.io/ketchbrookanalytics/quarto-pdf-dev` carries four kind
 
 The [devcontainer](.devcontainer/) and an in-flight project's [Dockerfile](Dockerfile) should stay on `:latest`, so ongoing work picks up patches. Pin to `vX.Y.Z` only at handoff, alongside locking `renv.lock`.
 
+`latest` and the semver tags are only applied *after* the smoke test passes on both architectures, so a build that can't render never becomes anyone's `latest` — it just leaves those tags on the previous image. `sha-` tags are the exception: they are pushed before the test runs, so one exists for every build including failed ones. Pin a released `vX.Y.Z`, not a `sha-`.
+
 > [!NOTE]
 > The weekly rebuild runs cache-less on purpose, so it takes on the order of ten minutes rather than seconds. A scheduled run that finishes in well under a minute means the cache is being restored and **no patches are landing** — the manifest digest still changes every week regardless, because of the image's `created` timestamp label, so digest churn is not evidence of a real rebuild.
 >
-> Every published image is smoke-tested by rendering [report.qmd](report.qmd) inside it ([.github/scripts/smoke-test.sh](.github/scripts/smoke-test.sh)). Pushes to `main` test `linux/amd64`; the weekly and release runs also test `linux/arm64`, each on a native runner. The same script is a handy way to reproduce a suspected image problem locally:
+> Every build is smoke-tested by rendering [report.qmd](report.qmd) inside the image ([.github/scripts/smoke-test.sh](.github/scripts/smoke-test.sh)), on `linux/amd64` and `linux/arm64`, each on a native runner. The same script is a handy way to reproduce a suspected image problem locally:
 >
 > ```bash
 > docker run --rm -v "$PWD:/project" -w /project \
@@ -176,7 +178,7 @@ A revert counts as a change: moving R back down is a **minor** bump forward, not
 ### Cutting a release
 
 1. Move the `## [Unreleased]` entries in [CHANGELOG.md](CHANGELOG.md) under a new `## [X.Y.Z] - YYYY-MM-DD` heading, confirm the dependency-stack line at the top of the section matches [Dockerfile.base](Dockerfile.base), and update the link definitions at the bottom of the file.
-2. Merge to `main` and wait for the [publish workflow](.github/workflows/publish-image.yml) to push a fresh `latest`.
+2. Merge to `main` and wait for the [publish workflow](.github/workflows/publish-image.yml) to go green. Its three jobs run in order: `publish` builds and pushes the `sha-` tag, `smoke` renders the report on both architectures, and `promote` then moves `latest`. If `smoke` fails, nothing is promoted — fix the image before releasing.
 3. Publish the release, which triggers the workflow again to stamp the semver tags:
 
     ```bash

--- a/README.md
+++ b/README.md
@@ -151,13 +151,15 @@ The [devcontainer](.devcontainer/) and an in-flight project's [Dockerfile](Docke
 > [!NOTE]
 > The weekly rebuild runs cache-less on purpose, so it takes on the order of ten minutes rather than seconds. A scheduled run that finishes in well under a minute means the cache is being restored and **no patches are landing** — the manifest digest still changes every week regardless, because of the image's `created` timestamp label, so digest churn is not evidence of a real rebuild.
 >
-> Every published image is smoke-tested by rendering [report.qmd](report.qmd) inside it ([.github/scripts/smoke-test.sh](.github/scripts/smoke-test.sh)). Pushes to `main` test `linux/amd64` only; the weekly and release runs also test `linux/arm64` under emulation, which is why those runs take substantially longer. The same script is a handy way to reproduce a suspected image problem locally:
+> Every published image is smoke-tested by rendering [report.qmd](report.qmd) inside it ([.github/scripts/smoke-test.sh](.github/scripts/smoke-test.sh)). Pushes to `main` test `linux/amd64`; the weekly and release runs also test `linux/arm64`, each on a native runner. The same script is a handy way to reproduce a suspected image problem locally:
 >
 > ```bash
 > docker run --rm -v "$PWD:/project" -w /project \
 >   ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest \
 >   bash .github/scripts/smoke-test.sh
 > ```
+>
+> Add `--platform linux/arm64` to reproduce an arm64 problem, but do it on arm64 hardware. Under QEMU emulation the render fails when Quarto drives Chrome Headless Shell (`AssertionError` … `Child process has already terminated`) even when the image itself is fine — the identical render passes with the mermaid diagrams removed. That is why CI smoke-tests arm64 on a native runner rather than through the emulation layer it builds with.
 >
 > Note what the weekly rebuild does *not* refresh: packages baked into the `rocker/r-ver` parent image stay frozen until either Rocker republishes that tag or we bump `R_VERSION`. Only the layers `Dockerfile.base` builds itself — the `apt-get` installs, Quarto, Chrome Headless Shell, `{pak}`, `{renv}` — get picked up fresh.
 

--- a/README.md
+++ b/README.md
@@ -149,9 +149,17 @@ The base image at `ghcr.io/ketchbrookanalytics/quarto-pdf-dev` carries four kind
 The [devcontainer](.devcontainer/) and an in-flight project's [Dockerfile](Dockerfile) should stay on `:latest`, so ongoing work picks up patches. Pin to `vX.Y.Z` only at handoff, alongside locking `renv.lock`.
 
 > [!NOTE]
-> The weekly rebuild runs cache-less on purpose, so it takes ~8 minutes rather than seconds. A scheduled run that finishes in well under a minute means the cache is being restored and **no patches are landing** — the manifest digest still changes every week regardless, because of the image's `created` timestamp label, so digest churn is not evidence of a real rebuild.
+> The weekly rebuild runs cache-less on purpose, so it takes on the order of ten minutes rather than seconds. A scheduled run that finishes in well under a minute means the cache is being restored and **no patches are landing** — the manifest digest still changes every week regardless, because of the image's `created` timestamp label, so digest churn is not evidence of a real rebuild.
 >
-> Note also what the weekly rebuild does *not* refresh: packages baked into the `rocker/r-ver` parent image stay frozen until either Rocker republishes that tag or we bump `R_VERSION`. Only the layers `Dockerfile.base` builds itself — the `apt-get` installs, Quarto, Chrome Headless Shell, `{pak}`, `{renv}` — get picked up fresh.
+> Every published image is smoke-tested by rendering [report.qmd](report.qmd) inside it ([.github/scripts/smoke-test.sh](.github/scripts/smoke-test.sh)), which is also a handy way to reproduce a suspected image problem locally:
+>
+> ```bash
+> docker run --rm -v "$PWD:/project" -w /project \
+>   ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest \
+>   bash .github/scripts/smoke-test.sh
+> ```
+>
+> Note what the weekly rebuild does *not* refresh: packages baked into the `rocker/r-ver` parent image stay frozen until either Rocker republishes that tag or we bump `R_VERSION`. Only the layers `Dockerfile.base` builds itself — the `apt-get` installs, Quarto, Chrome Headless Shell, `{pak}`, `{renv}` — get picked up fresh.
 
 ### What bumps which number
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ renv::snapshot()
 
 The resulting `renv.lock` file will be used by Docker during build time to install the exact R package dependencies used in the project via `renv::restore()`.
 
-For a *fully* reproducible build, also pin the base image at this point. The [Dockerfile](Dockerfile) references `ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest`, which tracks the newest base. Replace `:latest` with the immutable `:sha-...` tag of a specific published base (visible on the [package page](https://github.com/ketchbrookanalytics/quarto-pdf-dev/pkgs/container/quarto-pdf-dev)) so the R/Quarto versions can't drift after handoff.
+For a *fully* reproducible build, also pin the base image at this point. The [Dockerfile](Dockerfile) references `ghcr.io/ketchbrookanalytics/quarto-pdf-dev:latest`, which tracks the newest base. Replace `:latest` with a released version tag so the R/Quarto versions can't drift after handoff:
+
+```dockerfile
+FROM ghcr.io/ketchbrookanalytics/quarto-pdf-dev:v0.2.0
+```
+
+Available tags are listed on the [package page](https://github.com/ketchbrookanalytics/quarto-pdf-dev/pkgs/container/quarto-pdf-dev), and each release's dependency stack is recorded in [CHANGELOG.md](CHANGELOG.md). See [Versioning & Releases](#versioning--releases) below for what the tags mean.
 
 Commit and push the changes to the repository. You're now ready to hand off this repository to others who want to reproduce your work.
 
@@ -125,6 +131,45 @@ The middle lines of the above command represent communication between our local 
 - `-v "$(pwd)/data:/project/data:ro"` allows the container "Read-only" access to the local folder named `data/` in the current working directory. This is only necessary if you have a git-ignored folder called `data/` locally.
 - `-v "$(pwd)/_output:/project/_output"` allows the container to write to a folder (which may or may not already exist; if it doesn't exist, it will be created) named `_output/` in the current working directory.
 
+## Versioning & Releases
+
+This template's real product is a *pinned dependency stack* — a specific R version, a specific Quarto version, and the tooling around them. Those dependencies get updated periodically, and occasionally an update has to be walked back (as with the R 4.6.0 → 4.5.2 revert in [#20](https://github.com/ketchbrookanalytics/quarto-pdf-dev/issues/20)). Releases exist so a project handed off six months ago can name the exact stack it was built against.
+
+### Image tags
+
+The base image at `ghcr.io/ketchbrookanalytics/quarto-pdf-dev` carries four kinds of tag:
+
+| Tag | Moves? | Use it for |
+| --- | --- | --- |
+| `v0.2.0`, `0.2.0` | Never | **Handoffs.** Pins one exact dependency stack. |
+| `0.2` | On patch re-releases | Tracking fixes within a minor line. |
+| `latest` | Every build of `main`, including the weekly rebuild | **Active development.** Gets OS/security patches automatically. |
+| `sha-abc1234` | Never | Tracing a specific image back to a commit. |
+
+The [devcontainer](.devcontainer/) and an in-flight project's [Dockerfile](Dockerfile) should stay on `:latest`, so ongoing work picks up patches. Pin to `vX.Y.Z` only at handoff, alongside locking `renv.lock`.
+
+### What bumps which number
+
+| Change | Bump |
+| --- | --- |
+| A dependency change that can invalidate an existing `renv.lock` — an R minor-version jump (`4.5.x` → `4.6.x`), which changes the binary package line | **Major** |
+| Anything else that changes the dependency stack: R patch versions, Quarto versions, `{renv}` versions, new system libraries, new devcontainer tooling | **Minor** |
+| Docs, workflow plumbing, Typst/template tweaks, and fixes that leave the dependency stack untouched | **Patch** |
+
+A revert counts as a change: moving R back down is a **minor** bump forward, not a rollback to an older version number.
+
+### Cutting a release
+
+1. Move the `## [Unreleased]` entries in [CHANGELOG.md](CHANGELOG.md) under a new `## [X.Y.Z] - YYYY-MM-DD` heading, confirm the dependency-stack line at the top of the section matches [Dockerfile.base](Dockerfile.base), and update the link definitions at the bottom of the file.
+2. Merge to `main` and wait for the [publish workflow](.github/workflows/publish-image.yml) to push a fresh `latest`.
+3. Publish the release, which triggers the workflow again to stamp the semver tags:
+
+    ```bash
+    gh release create vX.Y.Z --title vX.Y.Z --notes "See CHANGELOG.md for details."
+    ```
+
+4. Confirm the new tags appear on the [package page](https://github.com/ketchbrookanalytics/quarto-pdf-dev/pkgs/container/quarto-pdf-dev).
+
 ## Structure
 
 This repository contains the following components:
@@ -139,6 +184,7 @@ This repository contains the following components:
 - [qmd/](qmd/) contains the [Quarto child documents](https://quarto.org/docs/authoring/includes.html) that make up most of the report narrative and detail.
 - [_quarto.yml](_quarto.yml) specifies the different [options](https://quarto.org/docs/reference/formats/typst.html) Quarto provides for rendering Typst PDF documents, and also passes variables to [typst-show.typ](assets/typst-show.typ) which, in turn, passes values to [typst-template.typ](assets/typst-template.typ).
 - [air.toml](air.toml) instantiates the project's use of [Air](https://posit-dev.github.io/air/) for R code formatting.
+- [CHANGELOG.md](CHANGELOG.md) records what changed in each release of the template, including the R/Quarto/`{renv}` versions that release ships.
 - [Dockerfile.base](Dockerfile.base) defines the reusable `dev` base image (R, Quarto, Chrome Headless Shell, `pak`, `renv`). It is published to `ghcr.io/ketchbrookanalytics/quarto-pdf-dev` by [.github/workflows/publish-image.yml](.github/workflows/publish-image.yml) and is shared, unchanged, across every report project.
 - [Dockerfile](Dockerfile) builds the project-specific deployment image directly on top of that published base (adding `assets/`, `qmd/`, `renv::restore()`, etc.) at the conclusion of the project.
 - [report.qmd](report.qmd) is an example Quarto report that showcases how to include tables, plots, and diagrams.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The [devcontainer](.devcontainer/) and an in-flight project's [Dockerfile](Docke
 > [!NOTE]
 > The weekly rebuild runs cache-less on purpose, so it takes on the order of ten minutes rather than seconds. A scheduled run that finishes in well under a minute means the cache is being restored and **no patches are landing** — the manifest digest still changes every week regardless, because of the image's `created` timestamp label, so digest churn is not evidence of a real rebuild.
 >
-> Every published image is smoke-tested by rendering [report.qmd](report.qmd) inside it ([.github/scripts/smoke-test.sh](.github/scripts/smoke-test.sh)), which is also a handy way to reproduce a suspected image problem locally:
+> Every published image is smoke-tested by rendering [report.qmd](report.qmd) inside it ([.github/scripts/smoke-test.sh](.github/scripts/smoke-test.sh)). Pushes to `main` test `linux/amd64` only; the weekly and release runs also test `linux/arm64` under emulation, which is why those runs take substantially longer. The same script is a handy way to reproduce a suspected image problem locally:
 >
 > ```bash
 > docker run --rm -v "$PWD:/project" -w /project \

--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ The base image at `ghcr.io/ketchbrookanalytics/quarto-pdf-dev` carries four kind
 
 The [devcontainer](.devcontainer/) and an in-flight project's [Dockerfile](Dockerfile) should stay on `:latest`, so ongoing work picks up patches. Pin to `vX.Y.Z` only at handoff, alongside locking `renv.lock`.
 
+> [!NOTE]
+> The weekly rebuild runs cache-less on purpose, so it takes ~8 minutes rather than seconds. A scheduled run that finishes in well under a minute means the cache is being restored and **no patches are landing** — the manifest digest still changes every week regardless, because of the image's `created` timestamp label, so digest churn is not evidence of a real rebuild.
+>
+> Note also what the weekly rebuild does *not* refresh: packages baked into the `rocker/r-ver` parent image stay frozen until either Rocker republishes that tag or we bump `R_VERSION`. Only the layers `Dockerfile.base` builds itself — the `apt-get` installs, Quarto, Chrome Headless Shell, `{pak}`, `{renv}` — get picked up fresh.
+
 ### What bumps which number
 
 | Change | Bump |


### PR DESCRIPTION
Closes #20.

## The fix

R 4.6.0 breaks the vscode-R session watcher, so `View()` on a `{gt}` table fails with `unable to start data viewer` inside the devcontainer ([vscode-R#1696](https://github.com/REditorSupport/vscode-R/issues/1696)). This pins `R_VERSION` back to **4.5.2** in `Dockerfile.base` — the version @dmhhughes confirmed both fixes the viewer *and* still renders the example report — rather than shipping the `.Rprofile` workaround. The comment on `R_VERSION` records the condition for moving back to 4.6.x: the upstream fix reaching the vscode-R marketplace release.

## The tagging piece

A dependency revert is exactly the situation where a handoff needs a stable name for the stack it was built against. Today the base image only publishes `latest` and `sha-<commit>`, so "the R 4.5.2 base" has no durable name and the README tells you to pin `:sha-abc1234`.

**Publishing a `vX.Y.Z` GitHub Release now stamps the image with semver tags:**

| Tag | Moves? | Use it for |
| --- | --- | --- |
| `v0.2.0`, `0.2.0` | Never | Handoffs — pins one exact dependency stack |
| `0.2` | On patch re-releases | Fixes within a minor line |
| `latest` | Every `main` build, incl. the weekly rebuild | Active development |
| `sha-abc1234` | Never | Tracing an image to a commit |

`latest` deliberately keeps tracking `main`, so in-flight projects still pick up the weekly OS/security rebuild. Pinning happens at handoff, not before — the devcontainer stays on `:latest`.

Two implementation notes worth a reviewer's eye:

- This uses a **`release: types: [published]` trigger, not a `push` tag filter.** The workflow's existing `paths:` filter would also apply to tag pushes, which would silently skip publishing for any release that doesn't happen to touch `Dockerfile.base` — a quiet failure mode where the release exists but the image tag never appears.
- The `type=semver` entries are inert on branch and scheduled builds, so `main` push behavior is unchanged.

**Docs:**

- `CHANGELOG.md` (new) records each release plus the R/Quarto/`{renv}` versions it ships, backfilled from everything since `v0.1.0`.
- README gains a **Versioning & Releases** section: what each tag means, which dependency changes bump which number (R minor jumps → major, since they invalidate an existing `renv.lock`; other stack changes → minor; docs/plumbing → patch), and the steps to cut a release.
- Handoff guidance in the README and `Dockerfile` now points at `:vX.Y.Z` instead of `:sha-abc1234`.

## Follow-up after merge

The CHANGELOG entries are under `## [Unreleased]` on purpose — nothing is released until someone cuts it. Post-merge, per the README's new "Cutting a release" steps: rename that heading to `## [0.2.0] - <date>`, then `gh release create v0.2.0`. That's what produces the first semver-tagged base image. Minor rather than major under the new policy, since 4.6.0 → 4.5.2 is a patch-level move within the `4.5.x`/`4.6.x` boundary... worth confirming you agree with that read, since it's the first application of the policy.

## Testing notes

The image build itself isn't exercised by this PR — the publish workflow only runs on `main`. Worth confirming the `rocker/r-ver:4.5.2` base still builds multi-arch on merge, and that `View()` on a `{gt}` table works in a rebuilt devcontainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
