### PR TITLE
Close out the 0.2.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ every release note calls out the versions it ships.
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [0.2.0] - 2026-07-28
+
 Dependency stack: **R 4.5.2**, **Quarto 1.9.38**, **`{renv}` 1.2.3**
 
 ### Added
@@ -82,5 +86,6 @@ Dependency stack: **R 4.5.2**, **Quarto 1.9.38**, **`{renv}` 1.2.3**
 
 Initial release.
 
-[Unreleased]: https://github.com/ketchbrookanalytics/quarto-pdf-dev/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/ketchbrookanalytics/quarto-pdf-dev/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/ketchbrookanalytics/quarto-pdf-dev/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ketchbrookanalytics/quarto-pdf-dev/releases/tag/v0.1.0


### PR DESCRIPTION
Prep for releasing version `v0.2.0`. Renames `## [Unreleased]` to `## [0.2.0] - 2026-07-28`, adds the compare-link definitions, and leaves an empty `Unreleased` section for the next round.

**Minor, not major** — per the [policy](README.md#what-bumps-which-number), R 4.6.0 → 4.5.2 sits in the "changes the dependency stack" band rather than the "can invalidate an existing `renv.lock`" band. That top band is meant for crossing an R minor version in a way that strands work already built against it, and nothing has been handed off pinned to a 4.6.0 base, so nobody is stranded.

This is CHANGELOG-only, so it won't trigger the publish workflow — the `paths` filter covers `Dockerfile.base` and the workflow file. Publishing the release afterward is what triggers it.

## TODO

After merging, run

```bash
gh release create v0.2.0 --title v0.2.0 --notes "See CHANGELOG.md for details."
```

That fires the `release: published` trigger and exercises the one path in the new machinery that has never run: semver promotion. Expect `0.2.0`, `v0.2.0`, and `0.2` on the [package page](https://github.com/ketchbrookanalytics/quarto-pdf-dev/pkgs/container/quarto-pdf-dev), and **not** a new `latest` tag (note that `latest` only moves on the default branch, by design).

Two things not to misread when it runs:

- The release build produces a **new digest from identical layers**, because the `created` timestamp label changes. `v0.2.0` and `latest` will therefore be different digests pointing at the same content. Expected, not a discrepancy.
- The release build uses the layer cache (only `schedule` runs cache-less), so it should be fast. That's fine here — the content was already built and smoke-tested from scratch on the merge run.