### PR TITLE
Recommend the SimpleEnglish plugin in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ The devcontainer also offers the following additional features:
 - Use of [Air](https://posit-dev.github.io/air/) for R code formatting.
 - [Claude Code](https://code.claude.com/docs/en/vs-code) VSCode extension for AI-assisted development.
 
+### Recommended Claude Code Plugins
+
+Reports written from this template are read by clients, auditors, and examiners, so the prose matters as much as the numbers. We recommend installing [SimpleEnglish](https://github.com/AminBlg/SimpleEnglish), a plugin that applies [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/): short sentences, one word with one meaning, active voice, and the condition stated before the instruction.
+
+Install it once per machine from a Claude Code session:
+
+```
+/plugin marketplace add AminBlg/SimpleEnglish
+/plugin install simple-english@simple-english
+```
+
+Then ask Claude to apply it when drafting or revising narrative sections.
+
+> [!NOTE]
+> Plugins install per machine, not per repository, so each person working on a report installs this themselves. It is deliberately not baked into the [devcontainer](.devcontainer/) — the image pins a *dependency stack* that has to render identically years from now, and a writing-style plugin that updates on its own doesn't belong in that guarantee.
+
 ## Deployment
 
 ### Pre-Deployment Steps


### PR DESCRIPTION
Adds a **Recommended Claude Code Plugins** subsection to the README, under `### Features` where the rest of the tooling is listed.

## What and why

Reports built from this template may go to clients, auditors, and examiners, so the prose carries as much weight as the numbers. [SimpleEnglish](https://github.com/AminBlg/SimpleEnglish) applies [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/) — short sentences, one word with one meaning, active voice, condition before instruction — which suits the narrative sections of a validation report.

The section gives the two install commands and nothing more.

## Two decisions worth reviewing

**Documenting instead of vendoring.** Upstream already ships its own `marketplace.json` and `plugin.json`, so it installs directly. It is MIT licensed and actively maintained. Copying the skill into this repo would mean carrying the attribution and re-syncing against someone else's changes by hand, for content with nothing proprietary in it.

**Not in the devcontainer.** The obvious alternative was a `postCreateCommand` that pulls the latest version on every container create. Two reasons against it:

- The base image is `rocker/r-ver` + Quarto + `pak`, with no Node and no `claude` CLI, so this would mean installing a toolchain purely to run an install command — and it would only help devcontainer users, not anyone running Claude Code on the host.
- More importantly, the image exists to pin a dependency stack that renders identically years from now. A writing-style plugin that updates on its own does not belong inside that guarantee.

Both points are recorded in a `> [!NOTE]` in the README so the next person does not have to re-derive them.

## Testing

Docs only — no change to the image, the render, or any dependency. Nothing to smoke-test.