### PR TITLE
Allow Claude Code to edit the authoring surface without prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,27 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
+    "allow": [
+      "Edit(./*.qmd)",
+      "Edit(./qmd/**)",
+      "Edit(./R/**)",
+      "Edit(./_targets.R)",
+      "Edit(./assets/**)",
+      "Edit(./.devcontainer/**)",
+      "Edit(./CLAUDE.md)",
+      "Edit(./_quarto.yml)",
+      "Bash(quarto render:*)",
+      "Bash(quarto preview:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)"
+    ],
     "deny": [
       "Read(./.Renviron)",
-      "Read(./data/**)"
+      "Read(./data/**)",
+      "Edit(./.Renviron)",
+      "Edit(./data/**)"
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,28 @@ every release note calls out the versions it ships.
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- Permission allow rules in [.claude/settings.json](.claude/settings.json) so
+  Claude Code edits the authoring surface without a prompt per file: root
+  `*.qmd`, [qmd/](qmd/), [R/](R/), [_targets.R](_targets.R), [assets/](assets/),
+  [.devcontainer/](.devcontainer/), [CLAUDE.md](CLAUDE.md), and
+  [_quarto.yml](_quarto.yml). `Edit(...)` is the rule namespace for every
+  file-modifying tool, so `Write` and `NotebookEdit` are covered by the same
+  entries. Everything outside the list — `Dockerfile`, `.github/`, `.gitignore`,
+  and `.claude/settings.json` itself — still prompts.
+- Allow rules for `quarto render` / `quarto preview` and read-only `git`
+  (`status`, `diff`, `log`, `show`), so an iterate-and-render loop does not stop
+  on a prompt each pass. Only rules that hold for anyone using this template
+  belong here; organization-specific rules (a `gh api` allowance scoped to your
+  own GitHub org, for instance) belong in the downstream project repository, not
+  in the template.
+
+### Changed
+
+- `.Renviron` and `data/**` are now denied for editing as well as reading. The
+  previous rules blocked reads only, which left a git-ignored secrets file
+  overwritable.
 
 ## [0.2.0] - 2026-07-28
 


### PR DESCRIPTION
Claude Code prompted for approval on every write to the files this template exists to author, so an edit-render loop stopped once per file. This adds a permission allowlist to `.claude/settings.json`.

## Allowed without prompting

| Rule | Covers |
| --- | --- |
| `Edit(./*.qmd)` | root `report.qmd` (`*` does not cross `/`, so it stays at the root) |
| `Edit(./qmd/**)` | the child documents |
| `Edit(./R/**)`, `Edit(./_targets.R)` | the pipeline and its functions |
| `Edit(./assets/**)` | Typst partials and cover imagery |
| `Edit(./.devcontainer/**)` | the R package list lives in `postCreateCommand` |
| `Edit(./CLAUDE.md)`, `Edit(./_quarto.yml)` | project instructions and format config |
| `Bash(quarto render:*)`, `Bash(quarto preview:*)` | build the PDF, read Typst errors |
| `Bash(git status/diff/log/show:*)` | read-only inspection |

`Edit(...)` is the rule namespace for every file-modifying tool, so `Write` and `NotebookEdit` are covered by the same entries — no separate rules needed. Reads inside the project already don't prompt, which is why there are no `Read(...)` allow rules.

## Template-appropriate rules only

This repo is public and gets cloned by people outside our org, so only rules that hold for *any* user of the template belong here. Org- or client-specific rules belong in the downstream project repo, layered on top of what the template ships.

## Deliberately still prompting

`Dockerfile`, `Dockerfile.base`, `.github/`, `.gitignore`, `references.bib`, `air.toml`, and `.claude/settings.json` itself. The last one matters most: Claude cannot widen its own permissions without a human approving it.

## Deny rules extended

`.Renviron` and `data/**` were previously denied for *reading* only. Those hold secrets and proprietary data, and blocking reads while leaving writes open meant the git-ignored secrets file could still be modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
